### PR TITLE
Selecting a text color shouldn't toggle Format Brush on (Modeless design choice)

### DIFF
--- a/src/modals/cMenuToolbarModal.ts
+++ b/src/modals/cMenuToolbarModal.ts
@@ -236,10 +236,12 @@ export function setFontcolor(app: App, plugin: cMenuToolbarPlugin, color: string
     const editor = view.editor;
     let selectText = editor.getSelection();
     if (selectText == null || selectText.trim() == "") {
+      /*
       //如果没有选中内容激活格式刷
       quiteFormatbrushes(plugin);
       plugin.setEN_FontColor_Format_Brush(true);
       plugin.setTemp_Notice(new Notice(t("Font-Color formatting brush ON!"), 0));
+      */
       return;
     }
 


### PR DESCRIPTION
When the user is selecting a text color from the color pallet window don't automatically turn on Format_Brush when there isn't any selected text. The brush option should only toggled on and off manually by the user.